### PR TITLE
Removed legacy import for check_password in backend.py

### DIFF
--- a/fenixedu/authentication/backend.py
+++ b/fenixedu/authentication/backend.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.contrib.auth.models import User, check_password
+from django.contrib.auth.models import User
 
 class FenixEduAuthenticationBackend(object):
 	def add_info_to_session(self, request, fenixeduUser):


### PR DESCRIPTION
This method stopped being offered in a standalone version since django 1.9 ([ref](http://stackoverflow.com/questions/38063531/django-cannot-import-name-check-password)).